### PR TITLE
新增LTS内核选项 + 支持使用CDN下载

### DIFF
--- a/.github/workflows/build_lts.yml
+++ b/.github/workflows/build_lts.yml
@@ -1,0 +1,118 @@
+name: 构建带有BBRv3的LTS内核
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 删除旧的工作流运行记录
+        uses: Mattraks/delete-workflow-runs@main
+        with:
+          retain_days: 0       # 保留 0 天的记录
+          keep_minimum_runs: 0 # 至少保留 0 次记录
+
+  build:
+    needs: cleanup
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runs_on: ubuntu-22.04
+          - arch: arm64
+            runs_on: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runs_on }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      KERNEL_VERSION: ""
+    steps:
+      - name: 获取内核版本
+        id: get_kernel_version
+        run: |
+          version=$(curl -s https://www.kernel.org \
+            | grep -A1 -m1 "longterm:" \
+            | grep -oP '\d+\.\d+\.\d+')
+          echo "KERNEL_VERSION=$version" >> $GITHUB_ENV
+
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装依赖项
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            git build-essential \
+            libncurses-dev libssl-dev libelf-dev \
+            bison bc flex rsync debhelper \
+            dpkg-dev fakeroot kmod cpio dwarves \
+            lz4 zstd xz-utils curl jq
+
+      - name: 创建源码目录
+        run: mkdir -p ./kernel/linux
+
+      - name: 下载内核源代码
+        working-directory: ./kernel
+        run: |
+          branch=$(echo "${{ env.KERNEL_VERSION }}" | grep -oP '^\d+\.\d+')
+          git clone --depth=1 --branch linux-$branch.y \
+            https://github.com/gregkh/linux.git linux
+
+      - name: 添加 Google BBRv3
+        working-directory: ./kernel/linux
+        run: |
+          git remote add google-bbr https://github.com/google/bbr.git
+          git fetch google-bbr
+          git checkout google-bbr/v3
+
+      - name: 更新 Makefile 中的版本号
+        working-directory: ./kernel/linux
+        run: |
+          IFS='.' read -r v p s <<< "${{ env.KERNEL_VERSION }}"
+          sed -i "s/^VERSION *=.*/VERSION = $v/" Makefile
+          sed -i "s/^PATCHLEVEL *=.*/PATCHLEVEL = $p/" Makefile
+          sed -i "s/^SUBLEVEL *=.*/SUBLEVEL = $s/" Makefile
+
+      - name: 准备 .config
+        working-directory: ./kernel/linux
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            curl -sSL https://raw.githubusercontent.com/byJoey/Actions-bbr-v3/main/arm64.config \
+              > .config
+            make ARCH=arm64 olddefconfig
+          else
+            curl -sSL https://raw.githubusercontent.com/byJoey/Actions-bbr-v3/main/x86-64.config \
+              > .config
+            make olddefconfig
+          fi
+
+      - name: 构建内核 Debian 包
+        working-directory: ./kernel/linux
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            make ARCH=arm64 bindeb-pkg -j$(nproc) LOCALVERSION=-joeyblog-bbrv3
+          else
+            make bindeb-pkg -j$(nproc) LOCALVERSION=-joeyblog-bbrv3
+          fi
+
+      - name: 上传配置文件
+        uses: actions/upload-artifact@v4
+        with:
+          name: config-${{ matrix.arch }}
+          path: ./kernel/linux/.config
+
+      - name: 上传 deb 包
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{ matrix.arch }}
+          path: ./kernel/linux-*.deb
+
+      - name: 发布到 GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ matrix.arch }}-${{ env.KERNEL_VERSION }}-LTS
+          files: ./kernel/linux-*.deb
+          body: "带有 BBRv3 的最新LTS内核，适用于 ${{ matrix.arch }} 架构"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ### 🌟 功能列表  
 
-👑 **一键安装 BBR v3 内核**  
+👑 **一键安装 BBR v3 内核（可选最新版/LTS版内核）**  
 🍰 **切换加速模式（BBR+FQ、BBR+CAKE 等）**  
 ⚙️ **开启/关闭 BBR 加速**  
 🗑️ **卸载内核，告别不需要的内核版本**  
@@ -39,9 +39,14 @@
 
 ### 🚀 如何使用？
 
-1. **一键运行**  
+- **一键运行**  
    ```bash
    bash <(curl -l -s https://raw.githubusercontent.com/byJoey/Actions-bbr-v3/refs/heads/main/install.sh)
+   ```
+
+- **国内下载慢的话用这个！**（使用CDN代理） 
+   ```bash
+   CDN=1 bash <(curl -L -l -s https://raw.staticdn.net/byJoey/Actions-bbr-v3/refs/heads/main/install.sh)
    ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 编译好的内核
-BASE_URL="https://api.github.com/repos/XDflight/Actions-bbr-v3/releases"
+BASE_URL="https://api.github.com/repos/byJoey/Actions-bbr-v3/releases"
 
 # 限制脚本仅支持基于 Debian/Ubuntu 的系统
 if ! command -v apt-get &> /dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -34,9 +34,10 @@ SYSCTL_CONF="/etc/sysctl.d/99-joeyblog.conf"
 
 # 函数：清理 sysctl.d 中的旧配置
 clean_sysctl_conf() {
-    sudo touch "$SYSCTL_CONF"
-    sudo sed -i '/net.core.default_qdisc/d' "$SYSCTL_CONF"
-    sudo sed -i '/net.ipv4.tcp_congestion_control/d' "$SYSCTL_CONF"
+    for filepath in /etc/sysctl.d/*.conf ; do
+        sudo sed -i '/net.core.default_qdisc/d' "$filepath"
+        sudo sed -i '/net.ipv4.tcp_congestion_control/d' "$filepath"
+    done
 }
 
 # 函数：询问是否永久保存更改
@@ -45,6 +46,7 @@ ask_to_save() {
     read -r SAVE
     if [[ "$SAVE" == "y" || "$SAVE" == "Y" ]]; then
         clean_sysctl_conf
+        sudo touch "$SYSCTL_CONF"
         echo "net.core.default_qdisc=$QDISC" | sudo tee -a "$SYSCTL_CONF" > /dev/null
         echo "net.ipv4.tcp_congestion_control=$ALGO" | sudo tee -a "$SYSCTL_CONF" > /dev/null
         sudo sysctl --system > /dev/null 2>&1

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# 编译好的内核
+BASE_URL="https://api.github.com/repos/XDflight/Actions-bbr-v3/releases"
+
 # 限制脚本仅支持基于 Debian/Ubuntu 的系统
 if ! command -v apt-get &> /dev/null; then
     echo -e "\033[31m此脚本仅支持基于 Debian/Ubuntu 的系统，请在支持 apt-get 的系统上运行！\033[0m"
@@ -108,7 +111,6 @@ install_packages() {
 # 函数：检查并安装最新版本
 install_latest_version() {
     echo -e "\033[36m正在从 GitHub 获取最新版本信息...\033[0m"
-    BASE_URL="https://api.github.com/repos/byJoey/Actions-bbr-v3/releases"
     RELEASE_DATA=$(curl -sL "$BASE_URL")
     if [[ -z "$RELEASE_DATA" ]]; then
         echo -e "\033[31m从 GitHub 获取版本信息失败。请检查网络连接或 API 状态。\033[0m"
@@ -119,7 +121,15 @@ install_latest_version() {
     [[ "$ARCH" == "aarch64" ]] && ARCH_FILTER="arm64"
     [[ "$ARCH" == "x86_64" ]] && ARCH_FILTER="x86_64"
 
-    LATEST_TAG_NAME=$(echo "$RELEASE_DATA" | jq -r --arg filter "$ARCH_FILTER" 'map(select(.tag_name | test($filter; "i"))) | sort_by(.published_at) | .[-1].tag_name')
+    LATEST_TAG_NAME=""
+    if [[ $1 -eq 1 ]]; then
+        # 如果是 LTS 版本，过滤出 LTS 标签
+        LATEST_TAG_NAME=$(echo "$RELEASE_DATA" | jq -r --arg filter "$ARCH_FILTER" 'map(select(.tag_name | test(($filter + ".*LTS"); "i"))) | sort_by(.published_at) | .[-1].tag_name')
+    else
+        # 否则获取最新版本
+        LATEST_TAG_NAME=$(echo "$RELEASE_DATA" | jq -r --arg filter "$ARCH_FILTER" 'map(select(.tag_name | test($filter; "i"))) | sort_by(.published_at) | .[-1].tag_name')
+    fi
+    LATEST_TAG_NAME=$(echo "$LATEST_TAG_NAME" | sed 's/-LTS//')
 
     if [[ -z "$LATEST_TAG_NAME" || "$LATEST_TAG_NAME" == "null" ]]; then
         echo -e "\033[31m未找到适合当前架构 ($ARCH) 的最新版本。\033[0m"
@@ -140,12 +150,15 @@ install_latest_version() {
     fi
 
     echo -e "\033[33m发现新版本或未安装内核，准备下载...\033[0m"
-    ASSET_URLS=$(echo "$RELEASE_DATA" | jq -r --arg tag "$LATEST_TAG_NAME" '.[] | select(.tag_name == $tag) | .assets[].browser_download_url')
-    
+    ASSET_URLS=$(echo "$RELEASE_DATA" | jq -r --arg tag "$LATEST_TAG_NAME" '.[] | select(.tag_name | test($tag; "i")) | .assets[].browser_download_url')
+
     rm -f /tmp/linux-*.deb
 
     for URL in $ASSET_URLS; do
         echo -e "\033[36m正在下载文件：$URL\033[0m"
+        if [[ CDN -eq 1 ]]; then
+            URL="https://hub.gitmirror.com/$URL"
+        fi
         wget -q --show-progress "$URL" -P /tmp/ || { echo -e "\033[31m下载失败：$URL\033[0m"; return 1; }
     done
     
@@ -154,7 +167,6 @@ install_latest_version() {
 
 # 函数：安装指定版本
 install_specific_version() {
-    BASE_URL="https://api.github.com/repos/byJoey/Actions-bbr-v3/releases"
     RELEASE_DATA=$(curl -s "$BASE_URL")
     if [[ -z "$RELEASE_DATA" ]]; then
         echo -e "\033[31m从 GitHub 获取版本信息失败。请检查网络连接或 API 状态。\033[0m"
@@ -197,6 +209,9 @@ install_specific_version() {
     
     for URL in $ASSET_URLS; do
         echo -e "\033[36m下载中：$URL\033[0m"
+        if [[ CDN -eq 1 ]]; then
+            URL="https://hub.gitmirror.com/$URL"
+        fi
         wget -q --show-progress "$URL" -P /tmp/ || { echo -e "\033[31m下载失败：$URL\033[0m"; return 1; }
     done
 
@@ -221,7 +236,7 @@ echo -e "\033[1;33m作者：Joey  |  博客：https://joeyblog.net  |  反馈群
 print_separator
 
 echo -e "\033[1;33m╭( ･ㅂ･)و ✧ 你可以选择以下操作哦：\033[0m"
-echo -e "\033[33m 1. 🚀 安装或更新 BBR v3 (最新版)\033[0m"
+echo -e "\033[33m 1. 🚀 安装或更新 BBR v3 (最新版/最新LTS版)\033[0m"
 echo -e "\033[33m 2. 📚 指定版本安装\033[0m"
 echo -e "\033[33m 3. 🔍 检查 BBR v3 状态\033[0m"
 echo -e "\033[33m 4. ⚡ 启用 BBR + FQ\033[0m"
@@ -235,7 +250,19 @@ read -r ACTION
 case "$ACTION" in
     1)
         echo -e "\033[1;32m٩(｡•́‿•̀｡)۶ 您选择了安装或更新 BBR v3！\033[0m"
-        install_latest_version
+        echo -n -e "\033[1;33m╭( ･ㅂ･)و ✧ 是否要安装最新LTS版本[y/N]：\033[0m"
+        read -r ACTION
+        lts=0
+        case "$ACTION" in
+            [yY][eE][sS]|[yY])
+                echo -e "\033[1;32m(｡♥‿♥｡) 正在安装最新LTS版本...\033[0m"
+                lts=1
+                ;;
+            *)
+                echo -e "\033[1;32m(｡♥‿♥｡) 正在安装最新版本...\033[0m"
+                ;;
+        esac
+        install_latest_version $lts
         ;;
     2)
         echo -e "\033[1;32m(｡･∀･)ﾉﾞ 您选择了安装指定版本的 BBR！\033[0m"


### PR DESCRIPTION
感谢佬做的工具！Orz

## 新增功能：
1. **可以构建并安装LTS版本内核！** 现在有一个新的workflow（`build_lts.yml`）用于拉取并构建最新LTS版本的内核，安装的时候也可以选择安装LTS内核，非常适合在对稳定性要求高的生产环境中使用。
2. **可以从CDN镜像站下载内核！** 之前我看到有issue提到github国内网速很慢（#5），凑巧这几天我在老米配置国内服务器也因为这个抓狂了很久˃⌓˂ 所以现在只需要定义环境变量`CDN=1`就可以从镜像站下载了哈哈，希望能帮助到一些人吧
